### PR TITLE
Change host to irc.ocf.berkeley.edu

### DIFF
--- a/kubernetes/thelounge.yml.erb
+++ b/kubernetes/thelounge.yml.erb
@@ -51,7 +51,7 @@ metadata:
   name: virtual-host-ingress
 spec:
   rules:
-    - host: irc.dev-kubernetes.ocf.berkeley.edu
+    - host: irc.ocf.berkeley.edu
       http:
         paths:
           - backend:


### PR DESCRIPTION
Use the real host instead of test host. After this we could also merge https://github.com/ocf/puppet/pull/584. (I wonder if I should also add `dev-irc.ocf.berkeley.edu`.)