### PR TITLE
add mount for config with secrets

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,3 +1,6 @@
+// NOTE: This file is not actually used in production. 
+// The production file is located in the Puppet private 
+// docker share since it contains secrets.
 module.exports = {
   public: true,
   host: '0.0.0.0',

--- a/kubernetes/thelounge.yml.erb
+++ b/kubernetes/thelounge.yml.erb
@@ -40,6 +40,14 @@ spec:
               periodSeconds: 5
           ports:
             - containerPort: 9000
+          volumeMounts:
+            - mountPath: /var/opt/thelounge/config.js
+              name: config
+      volumes:
+        - name: config
+          hostPath:
+            path: /opt/share/kubernetes/secrets/thelounge/config.js
+            type: File
       dnsPolicy: ClusterFirst
       dnsConfig:
         searches:


### PR DESCRIPTION
This is needed to store the password for WEBIRC in #8. It should mount on top of the config.js copied in.